### PR TITLE
refactor: remove duplicate initilializations (#1489)

### DIFF
--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -50,8 +50,8 @@ export class Socket<
   public readonly io: Manager<ListenEvents, EmitEvents>;
 
   public id: string;
-  public connected: boolean;
-  public disconnected: boolean;
+  public connected: boolean = false;
+  public disconnected: boolean = true;
 
   public auth: { [key: string]: any } | ((cb: (data: object) => void) => void);
   public receiveBuffer: Array<ReadonlyArray<any>> = [];
@@ -74,13 +74,6 @@ export class Socket<
     super();
     this.io = io;
     this.nsp = nsp;
-    this.ids = 0;
-    this.acks = {};
-    this.receiveBuffer = [];
-    this.sendBuffer = [];
-    this.connected = false;
-    this.disconnected = true;
-    this.flags = {};
     if (opts && opts.auth) {
       this.auth = opts.auth;
     }


### PR DESCRIPTION
The attributes were already initialized, resulting in duplicate lines
in the final bundle.

Related: https://github.com/socketio/socket.io/issues/4063


*Note*: the `socket.io.js` file is the generated output of `make socket.io.js`, and should not be manually modified.

### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


